### PR TITLE
Added Eventyret bootstrap snippet

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,3 +7,4 @@ vscode:
     - ms-python.python@2019.8.30787:TnGEOx35GXMhyKLjDGz9Aw==
     - formulahendry.auto-close-tag@0.5.6:oZ/8R2VhZEhkHsoeO57hSw==
     - mkaufman.HTMLHint@0.6.0:TdNYbCmjW8N3yiaPW4/adg==
+    - eventyret.bootstrap-4-cdn-snippet@1.2.3:7CBqCsMp6UjSKmG+LTaUGw==


### PR DESCRIPTION
Added my own bootstrap plugin to the config.
[Bootstrap 4 Snippet](https://marketplace.visualstudio.com/items?itemName=eventyret.bootstrap-4-cdn-snippet)
This is also tagged in slack for people to use where students can do `!bcdn` to get a full bootstrap ready template.